### PR TITLE
Guard against a crash trying to access a null filter

### DIFF
--- a/CameraControlLib/CameraProperty.cs
+++ b/CameraControlLib/CameraProperty.cs
@@ -114,6 +114,10 @@ namespace CameraControlLib
 
         public override void Refresh()
         {
+            if(_cameraControl == null)
+            {
+                return;
+            }
             int value;
             CameraControlFlags flags;
             _cameraControl.Get(_cameraProperty, out value, out flags);


### PR DESCRIPTION
A capture card was causing the program to crash trying to access a null filter